### PR TITLE
fix display strings and node choice

### DIFF
--- a/src/test/java/ru/funbox/jenkins/plugins/pipelineheavyjob/NodeWithWeightTest.java
+++ b/src/test/java/ru/funbox/jenkins/plugins/pipelineheavyjob/NodeWithWeightTest.java
@@ -51,8 +51,7 @@ public class NodeWithWeightTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("nodeWithWeight(label: 'label1', weight: 1) { echo 'test' }", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-        j.waitForCompletion(b);
-        j.assertLogContains("Finished: SUCCESS", b);
+        j.waitForMessage("Finished: SUCCESS", b);
     }
 
     @Test public void checkBuildWaitingInQueue() throws Exception {


### PR DESCRIPTION
Fixes issues:
- forcing the placeholder task and the subtasks to run on the same node;
- and ensure the subtask display strings are visible in jenkins so we can see which job is claiming the executor.